### PR TITLE
Near-finalized ingest of core-node socket data

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+PG_HOST=127.0.0.1
+PG_PORT=5433
+PG_USER=admin
+PG_PASSWORD=password
+PG_DATABASE=stacks_core_sidecar

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 jest.config.js
 migrations/
+coverage/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,6 +47,7 @@
       "name": "Jest",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": [
+        "--testTimeout=3600000",
         "--runInBand",
         "--no-cache",
         "--config",

--- a/migrations/1584604583726_blocks.ts
+++ b/migrations/1584604583726_blocks.ts
@@ -24,9 +24,14 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       type: 'bytea',
       notNull: true,
     },
+    canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
   })
   pgm.createIndex('blocks', 'block_height');
   pgm.createIndex('blocks', 'parent_block_hash');
+  pgm.createIndex('blocks', 'canonical');
 }
 
 /*

--- a/migrations/1584619633448_txs.ts
+++ b/migrations/1584619633448_txs.ts
@@ -8,21 +8,38 @@ export async function up(pgm: MigrationBuilder): Promise<void> {
       primaryKey: true,
       type: 'bytea',
     },
-    block_hash: {
+    tx_index: {
       notNull: true,
-      type: 'bytea'
+      type: 'smallint'
     },
-    tx_type: {
+    block_hash: {
+      type: 'bytea',
+      notNull: true,
+    },
+    block_height: {
+      type: 'integer',
+      notNull: true, 
+    },
+    type_id: {
       notNull: true,
       type: 'smallint',
     },
-    raw_tx: {
+    status: {
       notNull: true,
-      type: 'bytea'
-    }
+      type: 'smallint',
+    },
+    canonical: {
+      type: 'boolean',
+      notNull: true,
+    },
+    post_conditions: {
+      type: 'bytea',
+    },
   });
   pgm.createIndex('txs', 'block_hash')
-  pgm.createIndex('txs', 'tx_type');
+  pgm.createIndex('txs', 'type_id');
+  pgm.createIndex('txs', 'block_height');
+  pgm.createIndex('txs', 'canonical');
 }
 
 /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,6 +210,25 @@
       "integrity": "sha512-A+wfdVwD1Sxd/D3PPJI67Evo7q2fp15hCOFLB5jmzcS1MdN8BQdFm6j51Sti8xLN4qHmuYkicbFBUluGx2h63g==",
       "dev": true
     },
+    "@blockstack/stacks-transactions": {
+      "version": "github:blockstack/stacks-transactions-js#b083bd970fdac880280a33c5a5f502ebc055d003",
+      "from": "github:blockstack/stacks-transactions-js#b083bd970fdac880280a33c5a5f502ebc055d003",
+      "requires": {
+        "@types/bn.js": "^4.11.6",
+        "@types/elliptic": "^6.4.12",
+        "@types/lodash": "^4.14.149",
+        "@types/randombytes": "^2.0.0",
+        "@types/ripemd160": "^2.0.0",
+        "@types/sha.js": "^2.4.0",
+        "bn.js": "^4.11.8",
+        "c32check": "^1.0.1",
+        "elliptic": "^6.5.2",
+        "lodash": "^4.17.15",
+        "randombytes": "^2.1.0",
+        "ripemd160": "^2.0.2",
+        "sha.js": "^2.4.11"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -860,16 +879,16 @@
         "pretty-format": "^25.1.0"
       }
     },
-    "@types/js-sha512": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@types/js-sha512/-/js-sha512-0.7.0.tgz",
-      "integrity": "sha512-gPY2v4o+xBinnBDWREx8PzNM1IlHQ0VrP31sxVenRLX56Ssh0IcaQDGzSQBRZxscYYvirDDDsCDNGRcIL7K7Dw=="
-    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ=="
     },
     "@types/node": {
       "version": "13.7.4",
@@ -4346,11 +4365,6 @@
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
     },
-    "js-sha512": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
-      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5931,25 +5945,6 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
-    },
-    "stacks-transactions-js": {
-      "version": "github:blockstack/stacks-transactions-js#f9e93e42327d3e4e8f7e24412408a8f25db27e7e",
-      "from": "github:blockstack/stacks-transactions-js#f9e93e4",
-      "requires": {
-        "@types/bn.js": "^4.11.6",
-        "@types/elliptic": "^6.4.12",
-        "@types/js-sha512": "^0.7.0",
-        "@types/randombytes": "^2.0.0",
-        "@types/ripemd160": "^2.0.0",
-        "@types/sha.js": "^2.4.0",
-        "bn.js": "^4.11.8",
-        "c32check": "^1.0.1",
-        "elliptic": "^6.5.2",
-        "js-sha512": "^0.8.0",
-        "randombytes": "^2.1.0",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11"
-      }
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -25,15 +25,16 @@
     "node": ">=13"
   },
   "dependencies": {
+    "@blockstack/stacks-transactions": "github:blockstack/stacks-transactions-js#b083bd970fdac880280a33c5a5f502ebc055d003",
     "@types/node": "^13.7.4",
     "@types/pg": "^7.14.3",
     "big-integer": "^1.6.48",
+    "c32check": "^1.0.1",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "node-pg-migrate": "^4.2.3",
     "pg": "^7.18.2",
     "smart-buffer": "^4.1.0",
-    "stacks-transactions-js": "github:blockstack/stacks-transactions-js#f9e93e4",
     "ts-node": "^8.6.2",
     "typescript": "^3.7.5"
   },

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -71,8 +71,7 @@ export interface DbStxEvent extends DbAssetEvent {
 }
 
 export interface DbContractAssetEvent extends DbAssetEvent {
-  contract_id: string;
-  asset_name: string;
+  asset_identifier: string;
 }
 
 export interface DbFtEvent extends DbContractAssetEvent {

--- a/src/datastore/common.ts
+++ b/src/datastore/common.ts
@@ -1,23 +1,103 @@
+import * as crypto from 'crypto';
+import { hexToBuffer } from '../helpers';
+
 export interface DbBlock {
   block_hash: string;
   index_block_hash: string;
   parent_block_hash: string;
   parent_microblock: string;
   block_height: number;
+  /** Set to `true` if entry corresponds to the canonical chain tip */
+  canonical: boolean;
+}
+
+export enum DbTxTypeId {
+  TokenTransfer = 0x00,
+  SmartContract = 0x01,
+  ContractCall = 0x02,
+  PoisonMicroblock = 0x03,
+  Coinbase = 0x04,
+}
+
+export enum DbTxStatus {
+  Pending = 0,
+  Success = 1,
+  Failed = -1,
 }
 
 export interface DbTx {
   tx_id: string;
+  tx_index: number;
+  block_hash: string;
+  block_height: number;
+  type_id: DbTxTypeId;
+  status: number;
+  /** Set to `true` if entry corresponds to the canonical chain tip */
+  canonical: boolean;
+  post_conditions?: Buffer;
+}
+
+export enum DbAssetEventTypeId {
+  Transfer = 1,
+  Mint = 2,
+  Burn = 3,
+}
+
+export interface DbAssetEvent {
+  // /** The first 128 bits of sha256(uint32BE(event_index) + tx_id) */
+  // event_id: string;
+  event_index: number;
+  tx_id: string;
+  block_height: number;
+  type_id: DbAssetEventTypeId;
+  sender: string;
+  recipient: string;
+  /** Set to `true` if entry corresponds to the canonical chain tip */
+  canonical: boolean;
+}
+
+export interface DbStxEvent extends DbAssetEvent {
+  amount: BigInt;
+}
+
+export interface DbContractAssetEvent extends DbAssetEvent {
+  contract_id: string;
+  asset_name: string;
+}
+
+export interface DbFtEvent extends DbContractAssetEvent {
+  /** unsigned 128-bit integer */
+  amount: BigInt;
+}
+
+export interface DbNftEvent extends DbContractAssetEvent {
+  /** Raw Clarity value */
+  value: Buffer;
 }
 
 export interface DataStore {
   updateBlock(block: DbBlock): Promise<void>;
   getBlock(blockHash: string): Promise<DbBlock>;
+
   updateTx(tx: DbTx): Promise<void>;
   getTx(txId: string): Promise<DbTx>;
-  /*
-  updateAssetEvent(): Promise<void>;
-  updateStxEvent(): Promise<void>;
-  updateClarityEvent(): Promise<void>;
-  */
+
+  updateStxEvent(event: DbStxEvent): Promise<void>;
+
+  updateFtEvent(event: DbFtEvent): Promise<void>;
+
+  updateNftEvent(event: DbNftEvent): Promise<void>;
+}
+
+export function getAssetEventId(event_index: number, event_tx_id: string): string {
+  const buff = Buffer.alloc(4 + 32);
+  buff.writeUInt32BE(event_index, 0);
+  hexToBuffer(event_tx_id).copy(buff, 4);
+  const hashed = crypto
+    .createHash('sha256')
+    .update(buff)
+    .digest()
+    .slice(16)
+    .toString('hex');
+  return '0x' + hashed;
 }

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -3,9 +3,9 @@ import { DataStore, DbBlock, DbTx, DbStxEvent, DbFtEvent, DbNftEvent, DbSmartCon
 export class MemoryDataStore implements DataStore {
   readonly blocks: Map<string, DbBlock> = new Map();
   readonly txs: Map<string, DbTx> = new Map();
-  readonly stxEvents: Map<string, DbStxEvent> = new Map();
-  readonly ftEvents: Map<string, DbFtEvent> = new Map();
-  readonly nftEvents: Map<string, DbNftEvent> = new Map();
+  readonly stxTokenEvents: Map<string, DbStxEvent> = new Map();
+  readonly fungibleTokenEvents: Map<string, DbFtEvent> = new Map();
+  readonly nonFungibleTokenEvents: Map<string, DbNftEvent> = new Map();
   readonly smartContractEvents: Map<string, DbSmartContractEventTypeId> = new Map();
 
   updateBlock(block: DbBlock): Promise<void> {
@@ -35,17 +35,17 @@ export class MemoryDataStore implements DataStore {
   }
 
   updateStxEvent(event: DbStxEvent): Promise<void> {
-    this.stxEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+    this.stxTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 
   updateFtEvent(event: DbFtEvent): Promise<void> {
-    this.ftEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+    this.fungibleTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 
   updateNftEvent(event: DbNftEvent): Promise<void> {
-    this.nftEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+    this.nonFungibleTokenEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -1,4 +1,4 @@
-import { DataStore, DbBlock, DbTx, DbStxEvent, DbFtEvent, DbNftEvent } from './common';
+import { DataStore, DbBlock, DbTx, DbStxEvent, DbFtEvent, DbNftEvent, DbSmartContractEventTypeId } from './common';
 
 export class MemoryDataStore implements DataStore {
   readonly blocks: Map<string, DbBlock> = new Map();
@@ -6,6 +6,7 @@ export class MemoryDataStore implements DataStore {
   readonly stxEvents: Map<string, DbStxEvent> = new Map();
   readonly ftEvents: Map<string, DbFtEvent> = new Map();
   readonly nftEvents: Map<string, DbNftEvent> = new Map();
+  readonly smartContractEvents: Map<string, DbSmartContractEventTypeId> = new Map();
 
   updateBlock(block: DbBlock): Promise<void> {
     this.blocks.set(block.block_hash, { ...block });
@@ -45,6 +46,11 @@ export class MemoryDataStore implements DataStore {
 
   updateNftEvent(event: DbNftEvent): Promise<void> {
     this.nftEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+    return Promise.resolve();
+  }
+
+  updateSmartContractEvent(event: DbSmartContractEventTypeId): Promise<void> {
+    this.smartContractEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
     return Promise.resolve();
   }
 }

--- a/src/datastore/memory-store.ts
+++ b/src/datastore/memory-store.ts
@@ -1,8 +1,11 @@
-import { DataStore, DbBlock, DbTx } from './common';
+import { DataStore, DbBlock, DbTx, DbStxEvent, DbFtEvent, DbNftEvent } from './common';
 
 export class MemoryDataStore implements DataStore {
   readonly blocks: Map<string, DbBlock> = new Map();
   readonly txs: Map<string, DbTx> = new Map();
+  readonly stxEvents: Map<string, DbStxEvent> = new Map();
+  readonly ftEvents: Map<string, DbFtEvent> = new Map();
+  readonly nftEvents: Map<string, DbNftEvent> = new Map();
 
   updateBlock(block: DbBlock): Promise<void> {
     this.blocks.set(block.block_hash, { ...block });
@@ -28,5 +31,20 @@ export class MemoryDataStore implements DataStore {
       throw new Error(`Could not find tx by ID: ${txId}`);
     }
     return Promise.resolve(tx);
+  }
+
+  updateStxEvent(event: DbStxEvent): Promise<void> {
+    this.stxEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+    return Promise.resolve();
+  }
+
+  updateFtEvent(event: DbFtEvent): Promise<void> {
+    this.ftEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+    return Promise.resolve();
+  }
+
+  updateNftEvent(event: DbNftEvent): Promise<void> {
+    this.nftEvents.set(`${event.tx_id}_${event.event_index}`, { ...event });
+    return Promise.resolve();
   }
 }

--- a/src/datastore/postgres-store.ts
+++ b/src/datastore/postgres-store.ts
@@ -8,7 +8,16 @@ import {
   bufferToHexPrefixString,
   hexToBuffer,
 } from '../helpers';
-import { DataStore, DbBlock, DbTx, DbStxEvent, DbFtEvent, DbNftEvent, DbTxTypeId } from './common';
+import {
+  DataStore,
+  DbBlock,
+  DbTx,
+  DbStxEvent,
+  DbFtEvent,
+  DbNftEvent,
+  DbTxTypeId,
+  DbSmartContractEventTypeId,
+} from './common';
 import PgMigrate from 'node-pg-migrate';
 import * as path from 'path';
 
@@ -218,6 +227,9 @@ export class PgDataStore implements DataStore {
   }
   updateNftEvent(event: DbNftEvent): Promise<void> {
     throw new Error('not implemented.');
+  }
+  updateSmartContractEvent(event: DbSmartContractEventTypeId): Promise<void> {
+    throw new Error('Method not implemented.');
   }
 
   async close(): Promise<void> {

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -11,28 +11,12 @@ export enum CoreNodeEventType {
   FtMintEvent = 'ft_mint_event',
 }
 
-// TODO: core-node should use better encoding for this structure
-export interface StandardPrincipalData {
-  /** Version byte */
-  0: number;
-  /** 20 byte octet array */
-  1: number[];
-}
-
-// TODO: update when core is fixed (contracts should be valid token recipients)
-// TODO: core-node should use better encoding for this structure
-export type Principal = { Standard: StandardPrincipalData } | { Contract: any };
-
 // TODO: core-node should use a better encoding for this structure;
-export type NonStandardClarityValue = any;
-
-export interface ContractIdentifier {
-  issuer: StandardPrincipalData;
-  name: string;
-}
+export type NonStandardClarityValue = unknown;
 
 export interface AssetIdentifier {
-  contract_identifier: ContractIdentifier;
+  /** Fully qualified contract ID, e.g. "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.kv-store" */
+  contract_identifier: string;
   asset_name: string;
 }
 
@@ -43,35 +27,37 @@ export interface CoreNodeEventBase {
 export interface SmartContractEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.ContractEvent;
   contract_event: {
-    /** Currently encoded in Clarity literal syntax, e.g. "'ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.kv-store" */
+    /** Fully qualified contract ID, e.g. "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.kv-store" */
     contract_identifier: string;
     topic: string;
     value: NonStandardClarityValue;
+    /** Hex encoded Clarity value. */
+    raw_value: string;
   };
 }
 
 export interface StxTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.StxTransferEvent;
   stx_transfer_event: {
-    recipient: Principal;
-    sender: Principal;
-    amount: number | string;
+    recipient: string;
+    sender: string;
+    amount: string;
   };
 }
 
 export interface StxMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.StxMintEvent;
   stx_mint_event: {
-    recipient: Principal;
-    amount: number | string;
+    recipient: string;
+    amount: string;
   };
 }
 
 export interface StxBurnEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.StxBurnEvent;
   stx_burn_event: {
-    sender: Principal;
-    amount: number | string;
+    sender: string;
+    amount: string;
   };
 }
 
@@ -79,9 +65,11 @@ export interface NftTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.NftTransferEvent;
   nft_transfer_event: {
     asset_identifier: AssetIdentifier;
-    recipient: Principal;
-    sender: Principal;
+    recipient: string;
+    sender: string;
     value: NonStandardClarityValue;
+    /** Hex encoded Clarity value. */
+    raw_value: string;
   };
 }
 
@@ -89,8 +77,10 @@ export interface NftMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.NftMintEvent;
   nft_mint_event: {
     asset_identifier: AssetIdentifier;
-    recipient: Principal;
+    recipient: string;
     value: NonStandardClarityValue;
+    /** Hex encoded Clarity value. */
+    raw_value: string;
   };
 }
 
@@ -98,9 +88,9 @@ export interface FtTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.FtTransferEvent;
   ft_transfer_event: {
     asset_identifier: AssetIdentifier;
-    recipient: Principal;
-    sender: Principal;
-    amount: number | string;
+    recipient: string;
+    sender: string;
+    amount: string;
   };
 }
 
@@ -108,8 +98,8 @@ export interface FtMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.FtMintEvent;
   ft_mint_event: {
     asset_identifier: AssetIdentifier;
-    recipient: Principal;
-    amount: number | string;
+    recipient: string;
+    amount: string;
   };
 }
 

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -11,48 +11,106 @@ export enum CoreNodeEventType {
   FtMintEvent = 'ft_mint_event',
 }
 
-export interface SmartContractEvent {
+// TODO: core-node should use better encoding for this structure
+export interface StandardPrincipalData {
+  /** Version byte */
+  0: number;
+  /** 20 byte octet array */
+  1: number[];
+}
+
+// TODO: update when core is fixed (contracts should be valid token recipients)
+// TODO: core-node should use better encoding for this structure
+export type Principal = { Standard: StandardPrincipalData } | { Contract: any };
+
+// TODO: core-node should use a better encoding for this structure;
+export type NonStandardClarityValue = any;
+
+export interface ContractIdentifier {
+  issuer: StandardPrincipalData;
+  name: string;
+}
+
+export interface AssetIdentifier {
+  contract_identifier: ContractIdentifier;
+  asset_name: string;
+}
+
+export interface CoreNodeEventBase {
+  txid: string;
+}
+
+export interface SmartContractEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.ContractEvent;
   contract_event: {
+    /** Currently encoded in Clarity literal syntax, e.g. "'ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.kv-store" */
     contract_identifier: string;
     topic: string;
-    value: string;
+    value: NonStandardClarityValue;
   };
 }
 
-export interface StxTransferEvent {
+export interface StxTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.StxTransferEvent;
-  stx_transfer_event: any;
+  stx_transfer_event: {
+    recipient: Principal;
+    sender: Principal;
+    amount: number | string;
+  };
 }
 
-export interface StxMintEvent {
+export interface StxMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.StxMintEvent;
-  stx_mint_event: any;
+  stx_mint_event: {
+    recipient: Principal;
+    amount: number | string;
+  };
 }
 
-export interface StxBurnEvent {
+export interface StxBurnEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.StxBurnEvent;
-  stx_burn_event: any;
+  stx_burn_event: {
+    sender: Principal;
+    amount: number | string;
+  };
 }
 
-export interface NftTransferEvent {
+export interface NftTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.NftTransferEvent;
-  nft_transfer_event: any;
+  nft_transfer_event: {
+    asset_identifier: AssetIdentifier;
+    recipient: Principal;
+    sender: Principal;
+    value: NonStandardClarityValue;
+  };
 }
 
-export interface NftMintEvent {
+export interface NftMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.NftMintEvent;
-  nft_mint_event: any;
+  nft_mint_event: {
+    asset_identifier: AssetIdentifier;
+    recipient: Principal;
+    value: NonStandardClarityValue;
+  };
 }
 
-export interface FtTransferEvent {
+export interface FtTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.FtTransferEvent;
-  ft_transfer_event: any;
+  ft_transfer_event: {
+    asset_identifier: AssetIdentifier;
+    recipient: Principal;
+    sender: Principal;
+    amount: number | string;
+  };
 }
 
-export interface FtMintEvent {
+export interface FtMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.FtMintEvent;
-  ft_mint_event: any;
+  ft_mint_event: {
+    asset_identifier: AssetIdentifier;
+    recipient: Principal;
+    amount: number | string;
+  };
 }
 
 export type CoreNodeEvent =
@@ -67,7 +125,7 @@ export type CoreNodeEvent =
 
 export interface CoreNodeTxMessage {
   raw_tx: string;
-  result: any;
+  result: NonStandardClarityValue;
   success: boolean;
   txid: string;
 }

--- a/src/event-stream/core-node-message.ts
+++ b/src/event-stream/core-node-message.ts
@@ -14,12 +14,6 @@ export enum CoreNodeEventType {
 // TODO: core-node should use a better encoding for this structure;
 export type NonStandardClarityValue = unknown;
 
-export interface AssetIdentifier {
-  /** Fully qualified contract ID, e.g. "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.kv-store" */
-  contract_identifier: string;
-  asset_name: string;
-}
-
 export interface CoreNodeEventBase {
   txid: string;
 }
@@ -64,7 +58,8 @@ export interface StxBurnEvent extends CoreNodeEventBase {
 export interface NftTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.NftTransferEvent;
   nft_transfer_event: {
-    asset_identifier: AssetIdentifier;
+    /** Fully qualified asset ID, e.g. "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.contract-name.asset-name" */
+    asset_identifier: string;
     recipient: string;
     sender: string;
     value: NonStandardClarityValue;
@@ -76,7 +71,8 @@ export interface NftTransferEvent extends CoreNodeEventBase {
 export interface NftMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.NftMintEvent;
   nft_mint_event: {
-    asset_identifier: AssetIdentifier;
+    /** Fully qualified asset ID, e.g. "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.contract-name.asset-name" */
+    asset_identifier: string;
     recipient: string;
     value: NonStandardClarityValue;
     /** Hex encoded Clarity value. */
@@ -87,7 +83,8 @@ export interface NftMintEvent extends CoreNodeEventBase {
 export interface FtTransferEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.FtTransferEvent;
   ft_transfer_event: {
-    asset_identifier: AssetIdentifier;
+    /** Fully qualified asset ID, e.g. "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.contract-name.asset-name" */
+    asset_identifier: string;
     recipient: string;
     sender: string;
     amount: string;
@@ -97,7 +94,8 @@ export interface FtTransferEvent extends CoreNodeEventBase {
 export interface FtMintEvent extends CoreNodeEventBase {
   type: CoreNodeEventType.FtMintEvent;
   ft_mint_event: {
-    asset_identifier: AssetIdentifier;
+    /** Fully qualified asset ID, e.g. "ST2ZRX0K27GW0SP3GJCEMHD95TQGJMKB7G9Y0X1MH.contract-name.asset-name" */
+    asset_identifier: string;
     recipient: string;
     amount: string;
   };
@@ -118,6 +116,7 @@ export interface CoreNodeTxMessage {
   result: NonStandardClarityValue;
   success: boolean;
   txid: string;
+  tx_index: number;
 }
 
 export interface CoreNodeMessage {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -144,3 +144,17 @@ export function jsonStringify(obj: object): string {
 export function bufferToHexPrefixString(buff: Buffer): string {
   return '0x' + buff.toString('hex');
 }
+
+/**
+ * Decodes a `0x` prefixed hex string to a buffer.
+ * @param hex - A hex string with a `0x` prefix.
+ */
+export function hexToBuffer(hex: string): Buffer {
+  if (!hex.startsWith('0x')) {
+    throw new Error(`Hex string is missing the "0x" prefix: "${hex}"`);
+  }
+  if (hex.length % 2 !== 0) {
+    throw new Error(`Hex string is an odd number of digits: ${hex}`);
+  }
+  return Buffer.from(hex.substring(2), 'hex');
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -48,6 +48,20 @@ export function isEnum<T extends string, TEnumValue extends number>(
   return isEnum(enumVariable, value);
 }
 
+export function parseEnum<T extends string, TEnumValue extends number>(
+  enumVariable: { [key in T]: TEnumValue },
+  num: number,
+  invalidEnumErrorFormatter?: (val: number) => Error
+): TEnumValue {
+  if (isEnum(enumVariable, num)) {
+    return num;
+  } else if (invalidEnumErrorFormatter !== undefined) {
+    throw invalidEnumErrorFormatter(num);
+  } else {
+    throw new Error(`Failed to parse enum from value "${num}".`);
+  }
+}
+
 const enumMaps = new Map<object, Map<unknown, unknown>>();
 
 export function getEnumDescription<T extends string, TEnumValue extends number>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,13 +23,9 @@ async function handleClientMessage(clientSocket: Readable, db: DataStore): Promi
     return;
   }
   const parsedMsg = parseMessageTransactions(msg);
-  const stringified = jsonStringify(parsedMsg);
-  console.log(stringified);
-  const msgDerp = {
-    ...parsedMsg,
-    block_height: -1,
-  };
-  await db.updateBlock(msgDerp);
+  // const stringified = jsonStringify(parsedMsg);
+  // console.log(stringified);
+  await db.updateBlock({ ...parsedMsg, canonical: true });
 }
 
 async function startEventSocketServer(db: DataStore): Promise<void> {
@@ -60,12 +56,6 @@ async function startEventSocketServer(db: DataStore): Promise<void> {
   });
 }
 
-async function connectPgDb(): Promise<PgDataStore> {
-  const db = await PgDataStore.connect();
-  console.log(`db connected`);
-  return db;
-}
-
 async function init(): Promise<void> {
   let db: DataStore;
   switch (process.env['STACKS_SIDECAR_DB']) {
@@ -76,7 +66,7 @@ async function init(): Promise<void> {
     }
     case 'pg':
     case undefined: {
-      db = await connectPgDb();
+      db = await PgDataStore.connect();
       break;
     }
     default: {

--- a/src/p2p/tx.ts
+++ b/src/p2p/tx.ts
@@ -1,8 +1,8 @@
 import { BufferReader } from '../binary-reader';
 import { getEnumDescription } from '../helpers';
 import { StacksMessageParsingError, NotImplementedError } from '../errors';
-import * as clarityUtil from 'stacks-transactions-js/src/clarity/clarityTypes';
-import * as stacksTxUtil from 'stacks-transactions-js/src/utils';
+import { ClarityValue } from '@blockstack/stacks-transactions/src';
+import { BufferReader as stacksTxBufferReader } from '@blockstack/stacks-transactions/src/utils';
 
 enum SigHashMode {
   /** SingleSigHashMode */
@@ -168,7 +168,7 @@ interface TransactionPostConditionNonfungible {
   assetInfoId: AssetInfoTypeID.NonfungibleAsset; // u8
   principal: PostConditionPrincipal;
   asset: AssetInfo;
-  assetValue: clarityUtil.ClarityValue;
+  assetValue: ClarityValue;
   conditionCode: NonfungibleConditionCode; // u8
 }
 
@@ -202,7 +202,7 @@ interface TransactionPayloadContractCall {
   address: StacksAddress;
   contractName: string;
   functionName: string;
-  functionArgs: clarityUtil.ClarityValue[];
+  functionArgs: ClarityValue[];
 }
 
 interface TransactionPayloadSmartContract {
@@ -346,20 +346,20 @@ function readTransactionPayload(reader: BufferReader): TransactionPayload {
   }
 }
 
-function readClarityValue(reader: BufferReader): clarityUtil.ClarityValue {
+function readClarityValue(reader: BufferReader): ClarityValue {
   const remainingBuffer = reader.internalBuffer.slice(reader.readOffset);
-  const bufferReader = new stacksTxUtil.BufferReader(remainingBuffer);
-  const clarityVal = clarityUtil.ClarityValue.deserialize(bufferReader);
+  const bufferReader = new stacksTxBufferReader(remainingBuffer);
+  const clarityVal = ClarityValue.deserialize(bufferReader);
   return clarityVal;
 }
 
-function readClarityValueArray(reader: BufferReader): clarityUtil.ClarityValue[] {
+function readClarityValueArray(reader: BufferReader): ClarityValue[] {
   const valueCount = reader.readUInt32BE();
-  const values = new Array<clarityUtil.ClarityValue>(valueCount);
+  const values = new Array<ClarityValue>(valueCount);
   const remainingBuffer = reader.internalBuffer.slice(reader.readOffset);
-  const bufferReader = new stacksTxUtil.BufferReader(remainingBuffer);
+  const bufferReader = new stacksTxBufferReader(remainingBuffer);
   for (let i = 0; i < valueCount; i++) {
-    const clarityVal = clarityUtil.ClarityValue.deserialize(bufferReader);
+    const clarityVal = ClarityValue.deserialize(bufferReader);
     values[i] = clarityVal;
   }
   return values;

--- a/tests/datastore-tests.ts
+++ b/tests/datastore-tests.ts
@@ -5,7 +5,7 @@ import { PgDataStore, cycleMigrations, runMigrations } from '../src/datastore/po
 describe('in-memory datastore', () => {
   let db: MemoryDataStore;
 
-  beforeAll(() => {
+  beforeEach(() => {
     db = new MemoryDataStore();
   });
 
@@ -27,13 +27,10 @@ describe('in-memory datastore', () => {
 describe('postgres datastore', () => {
   let db: PgDataStore;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     process.env.PG_DATABASE = 'stacks_core_sidecar_test';
-    db = await PgDataStore.connect();
-  });
-
-  test('migrations', async () => {
     await cycleMigrations();
+    db = await PgDataStore.connect();
   });
 
   test('pg block store and retrieve', async () => {
@@ -82,7 +79,7 @@ describe('postgres datastore', () => {
     expect(retrievedTx).toEqual(tx);
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await db?.close();
     await runMigrations(undefined, 'down');
   });


### PR DESCRIPTION
* Closes https://github.com/blockstack/blockstack-core-sidecar/issues/12: Consume core-node socket messages

* Closes https://github.com/blockstack/blockstack-core-sidecar/issues/15: Consume Clarity values from core-node stream

* Progress on https://github.com/blockstack/blockstack-core-sidecar/issues/10: Define db schema

* Progress on https://github.com/blockstack/blockstack-core-sidecar/issues/8: Fork-tolerance, determine and pressure test approaches

The core-node event stream payloads are about finalized in PR https://github.com/blockstack/stacks-blockchain/pull/1319. This PR consumes all available core-node msg data and transforms into database-ready objects. 

Blocks, transactions, token events, and smart-contract events are transformed into a WIP db structure, along with some naive upserts implemented in a postgres datastore and an in-memory datastore. 

Careful consideration is going into the postgres schema in order to scale to large future datasets. An approach similar to bitcore's mongodb is being taken, i.e. rows have an indexed boolean value indicating their "canonical" (is valid for current chain-tip) state. This, along with an indexed block-height column should allow efficient adjustments for last N blocks during re-org events. Benchmarking will take place once mature table schemas and aggregate sql queries are ready. 